### PR TITLE
profle:write is required for unstarring/starring segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,9 @@ Stars or unstars a specific segment for the authenticated athlete.
 - **Output:** Success message confirming the action and the segment's new starred status.
 - **Errors:** Missing/invalid token, Invalid `segmentId`, Strava API errors (e.g., segment not found, rate limit).
 
+- **Notes:**
+  - Requires `profile:write` scope for star-ing and unstar-ing segments
+
 ---
 
 ### `get-segment-effort`

--- a/scripts/setup-auth.ts
+++ b/scripts/setup-auth.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'url';
 
 // Define required scopes for all current and planned tools
 // Explicitly request profile and activity read access.
-const REQUIRED_SCOPES = 'profile:read_all,activity:read_all,activity:read';
+const REQUIRED_SCOPES = 'profile:read_all,activity:read_all,activity:read,profile:write';
 const REDIRECT_URI = 'http://localhost'; // Must match one configured in Strava App settings
 
 const __filename = fileURLToPath(import.meta.url);


### PR DESCRIPTION
### Context

Star/Unstar was failing due to an auth issue. According to Strava API docs the `profile:write` scope is required for this action. 

### Changes

Added `profile:write` as a scope + added note in Readme. 

### Test Plan 
✅ Tested via Claude's MCP client environment

#### _Before_
<img width="747" alt="Screenshot 2025-06-03 at 5 19 50 PM" src="https://github.com/user-attachments/assets/f41d1f1c-a9c3-4b5d-923e-91874b6c147c" />

#### _After_
<img width="756" alt="Screenshot 2025-06-03 at 5 20 12 PM" src="https://github.com/user-attachments/assets/2d135618-e7e5-48bc-a4de-c0b2bf8dac5f" />
