### PR TITLE
Fixes get route tool for longer id

### DIFF
--- a/src/stravaClient.ts
+++ b/src/stravaClient.ts
@@ -966,7 +966,7 @@ export async function listAthleteRoutes(accessToken: string, page = 1, perPage =
  * @returns A promise that resolves to the detailed route data.
  * @throws Throws an error if the API request fails or the response format is unexpected.
  */
-export async function getRouteById(accessToken: string, routeId: number): Promise<StravaRoute> {
+export async function getRouteById(accessToken: string, routeId: string): Promise<StravaRoute> {
     const url = `routes/${routeId}`;
     try {
         const response = await stravaApi.get(url, {

--- a/src/tools/getRoute.ts
+++ b/src/tools/getRoute.ts
@@ -4,8 +4,10 @@ import { formatRouteSummary } from "../formatters.js"; // Import shared formatte
 
 // Zod schema for input validation
 const GetRouteInputSchema = z.object({
-    routeId: z.number().int().positive({ message: "Route ID must be a positive integer." }).describe("The unique identifier of the route to fetch.")
-});
+    routeId: z.string()
+        .regex(/^\d+$/, "Route ID must contain only digits")
+        .refine(val => val.length > 0, "Route ID cannot be empty")
+        .describe("The unique identifier of the route to fetch.")});
 
 type GetRouteInput = z.infer<typeof GetRouteInputSchema>;
 


### PR DESCRIPTION
**Bug**

When route id is larger than Number.MAX_SAFE_INTEGER, the get-route tool is unable to fetch the correct route.

**Solution proposal**

Change the routeId param type to string and validate it with regex to contain inly numbers