### PR TITLE
feat: add docker support for running the MCP server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+.git
+.env
+.env.*
+*.log
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src ./src
+
+RUN npm run build
+
+FROM node:20-alpine AS runner
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+
+RUN npm ci --omit=dev
+
+COPY --from=builder /app/dist ./dist
+
+CMD ["node", "dist/server.js"]

--- a/package.json
+++ b/package.json
@@ -1,14 +1,17 @@
 {
   "name": "strava-mcp-server",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "MCP server for Strava API",
   "mcpName": "io.github.r-huijts/strava-mcp",
   "repository": {
-    "type": "git", 
+    "type": "git",
     "url": "https://github.com/r-huijts/strava-mcp"
   },
   "main": "dist/server.js",
   "type": "module",
+  "engines": {
+    "node": ">=20.11.0"
+  },
   "scripts": {
     "build": "tsc",
     "start": "node dist/server.js",


### PR DESCRIPTION
It would be useful to add support for Docker to run this MCP server, since it would help avoid port conflicts with other running MCP servers.

I also explicitly specified the Node engine version in package.json as a pre-flight check.