### PR TITLE
feat: improve getActivityDetails tool - Relative Effort / Suffer Scor…

### DIFF
--- a/src/stravaClient.ts
+++ b/src/stravaClient.ts
@@ -239,6 +239,7 @@ const DetailedActivitySchema = z.object({
     gear: SummaryGearSchema,
     device_name: z.string().optional().nullable(),
     perceived_exertion: z.number().optional().nullable(),
+    suffer_score: z.number().optional().nullable(),
     // segment_efforts: // Add DetailedSegmentEffort schema if needed
     // splits_metric: // Add Split schema if needed
     // splits_standard: // Add Split schema if needed

--- a/src/tools/getActivityDetails.ts
+++ b/src/tools/getActivityDetails.ts
@@ -59,7 +59,7 @@ function formatActivityDetails(activity: StravaDetailedActivity): string {
     const avgSpeed = formatSpeed(activity.average_speed);
     const maxSpeed = formatSpeed(activity.max_speed);
     const avgPace = formatPace(activity.average_speed); // Calculate pace from speed
-
+    
     let details = `🏃 **${activity.name}** (ID: ${activity.id})\n`;
     details += `   - Type: ${activity.type} (${activity.sport_type})\n`;
     details += `   - Date: ${date}\n`;
@@ -79,7 +79,8 @@ function formatActivityDetails(activity: StravaDetailedActivity): string {
     if (activity.calories !== undefined) details += `   - Calories: ${activity.calories.toFixed(0)}\n`;
     if (activity.description) details += `   - Description: ${activity.description}\n`;
     if (activity.gear) details += `   - Gear: ${activity.gear.name}\n`;
-    if (activity.perceived_exertion) details += `   - perceived exertion: ${activity.perceived_exertion}\n`
+    if (activity.perceived_exertion) details += `   - perceived exertion: ${activity.perceived_exertion}\n`;
+    if (activity.suffer_score) details += `   - Relative effort (Training Impulse): ${activity.suffer_score}\n`
     return details;
 }
 


### PR DESCRIPTION
### Description
This PR enhances the getActivityDetails tool by including the **Relative Effort metric** (internally referred to as suffer_score in the Strava API).

Relative Effort is a heart-rate-based analysis inspired by the TRIMP (TRaining IMPulse) concept. Adding this field allows MCP-connected models (like Gemini or Claude) to better understand the physiological intensity of a workout, enabling more accurate coaching advice, effort comparisons, and activity summaries.

### Key Changes
src/tools/getActivityDetails.ts: Updated the interface and the tool execution logic to extract and return the suffer_score from the Strava API response - function formatActivityDetails extended to include Relative Effort metric, if this metric is available in Strava activity data

### Why this matters?
Without Relative Effort, an AI might see two 5km runs as identical. With this change, the AI can now see that one was a "Zone 2" jog while the other was an "all-out" effort, providing much deeper insights for the user.

### API Reference
Following the [Strava API Documentation](https://developers.strava.com/docs/reference/#api-Activities-getActivityById), **the field mapped is suffer_score (int).**

### Testing performed
[x] Verified via MCP Inspector that getActivityDetails now returns the suffer_score field.

[x] Confirmed that the model can interpret this score to describe workout intensity.

[x] Tested with activities both with and without heart rate data (returns null or is omitted gracefully when not available).

**Catchy "TL;DR" for the Maintainer**
"Let the AI feel the burn! 🔥 This PR adds Strava's 'Suffer Score' to the MCP server, giving models the context they need to tell the difference between a walk in the park and an epic mountain climb."
