### PR TITLE
fix: restore swim/climb stats and factor out repated activity logic

### DIFF
--- a/src/tools/getAthleteProfile.ts
+++ b/src/tools/getAthleteProfile.ts
@@ -50,15 +50,4 @@ export const getAthleteProfile = {
         };
       }
     }
-};
-
-// Removed old registration function
-/*
-export function registerGetAthleteProfileTool(server: McpServer) {
-  server.tool(
-    getAthleteProfile.name,
-    getAthleteProfile.description,
-    getAthleteProfile.execute // No input schema
-  );
-}
-*/ 
+}; 

--- a/src/tools/getAthleteStats.ts
+++ b/src/tools/getAthleteStats.ts
@@ -1,43 +1,15 @@
-// import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"; // Removed
 import { z } from "zod";
 import {
-    // getAuthenticatedAthlete as fetchAuthenticatedAthlete, // Removed
     getAthleteStats as fetchAthleteStats,
-    // handleApiError, // Removed unused import
-    StravaStats // Type needed for formatter
+    StravaStats
 } from "../stravaClient.js";
-// formatDuration is now local or in utils, not imported from server.ts
 
-// Input schema: Now requires athleteId
 const GetAthleteStatsInputSchema = z.object({
     athleteId: z.number().int().positive().describe("The unique identifier of the athlete to fetch stats for. Obtain this ID first by calling the get-athlete-profile tool.")
 });
 
-// Define type alias for input
 type GetAthleteStatsInput = z.infer<typeof GetAthleteStatsInputSchema>;
 
-// Remove unused formatDuration function
-/*
-function formatDuration(seconds: number): string {
-    if (isNaN(seconds) || seconds < 0) {
-        return 'N/A';
-    }
-    const hours = Math.floor(seconds / 3600);
-    const minutes = Math.floor((seconds % 3600) / 60);
-    const secs = Math.floor(seconds % 60);
-
-    const parts: string[] = [];
-    if (hours > 0) {
-        parts.push(hours.toString().padStart(2, '0'));
-    }
-    parts.push(minutes.toString().padStart(2, '0'));
-    parts.push(secs.toString().padStart(2, '0'));
-
-    return parts.join(':');
-}
-*/
-
-// Helper function to format numbers as strings with labels (metric)
 function formatStat(value: number | null | undefined, unit: 'km' | 'm' | 'hrs'): string {
     if (value === null || value === undefined) return 'N/A';
 
@@ -54,7 +26,19 @@ function formatStat(value: number | null | undefined, unit: 'km' | 'm' | 'hrs'):
     return `${formattedValue} ${unit}`;
 }
 
-// Format athlete stats (metric only)
+const activityTypes = [
+    { key: "ride", label: "Rides" },
+    { key: "run", label: "Runs" },
+    { key: "swim", label: "Swims" },
+] as const;
+
+type ActivityTotals = StravaStats["recent_ride_totals"];
+
+function getTotals(stats: StravaStats, prefix: "recent" | "ytd" | "all", type: "ride" | "run" | "swim"): ActivityTotals {
+    const key = `${prefix}_${type}_totals` as keyof StravaStats;
+    return stats[key] as ActivityTotals;
+}
+
 function formatStats(stats: StravaStats): string {
     const format = (label: string, total: number | null | undefined, unit: 'km' | 'm' | 'hrs', count?: number | null, time?: number | null) => {
         let line = `   - ${label}: ${formatStat(total, unit)}`;
@@ -63,54 +47,34 @@ function formatStats(stats: StravaStats): string {
         return line;
     };
 
+    const periods = [
+        { prefix: "recent", label: (type: string) => `*Recent ${type} (last 4 weeks):*` },
+        { prefix: "ytd", label: (type: string) => `*Year-to-Date ${type}:*` },
+        { prefix: "all", label: (type: string) => `*All-Time ${type}:*` },
+    ] as const;
+
     let response = "📊 **Your Strava Stats:**\n";
 
-    if (stats.biggest_ride_distance !== undefined) {
-        response += "**Rides:**\n";
-        response += format("Biggest Ride", stats.biggest_ride_distance, 'km') + '\n';
+    if (stats.biggest_ride_distance != null) {
+        response += format("Biggest Ride Distance", stats.biggest_ride_distance, 'km') + '\n';
     }
-    if (stats.recent_ride_totals) {
-        response += "*Recent Rides (last 4 weeks):*\n";
-        response += format("Distance", stats.recent_ride_totals.distance, 'km', stats.recent_ride_totals.count, stats.recent_ride_totals.moving_time) + '\n';
-        response += format("Elevation Gain", stats.recent_ride_totals.elevation_gain, 'm') + '\n';
-    }
-    if (stats.ytd_ride_totals) {
-        response += "*Year-to-Date Rides:*\n";
-        response += format("Distance", stats.ytd_ride_totals.distance, 'km', stats.ytd_ride_totals.count, stats.ytd_ride_totals.moving_time) + '\n';
-        response += format("Elevation Gain", stats.ytd_ride_totals.elevation_gain, 'm') + '\n';
-    }
-    if (stats.all_ride_totals) {
-        response += "*All-Time Rides:*\n";
-        response += format("Distance", stats.all_ride_totals.distance, 'km', stats.all_ride_totals.count, stats.all_ride_totals.moving_time) + '\n';
-        response += format("Elevation Gain", stats.all_ride_totals.elevation_gain, 'm') + '\n';
+    if (stats.biggest_climb_elevation_gain != null) {
+        response += format("Biggest Climb Elevation Gain", stats.biggest_climb_elevation_gain, 'm') + '\n';
     }
 
-    // Similar blocks for Runs and Swims if needed...
-    if (stats.recent_run_totals || stats.ytd_run_totals || stats.all_run_totals) {
-        response += "\n**Runs:**\n";
-        if (stats.recent_run_totals) {
-            response += "*Recent Runs (last 4 weeks):*\n";
-            response += format("Distance", stats.recent_run_totals.distance, 'km', stats.recent_run_totals.count, stats.recent_run_totals.moving_time) + '\n';
-            response += format("Elevation Gain", stats.recent_run_totals.elevation_gain, 'm') + '\n';
-        }
-        if (stats.ytd_run_totals) {
-             response += "*Year-to-Date Runs:*\n";
-             response += format("Distance", stats.ytd_run_totals.distance, 'km', stats.ytd_run_totals.count, stats.ytd_run_totals.moving_time) + '\n';
-             response += format("Elevation Gain", stats.ytd_run_totals.elevation_gain, 'm') + '\n';
-        }
-         if (stats.all_run_totals) {
-            response += "*All-Time Runs:*\n";
-            response += format("Distance", stats.all_run_totals.distance, 'km', stats.all_run_totals.count, stats.all_run_totals.moving_time) + '\n';
-            response += format("Elevation Gain", stats.all_run_totals.elevation_gain, 'm') + '\n';
+    for (const { key, label } of activityTypes) {
+        response += `\n**${label}:**\n`;
+        for (const period of periods) {
+            const totals = getTotals(stats, period.prefix, key);
+            response += period.label(label) + '\n';
+            response += format("Distance", totals.distance, 'km', totals.count, totals.moving_time) + '\n';
+            response += format("Elevation Gain", totals.elevation_gain, 'm') + '\n';
         }
     }
-
-    // Add Swims similarly if needed
 
     return response;
 }
 
-// Tool definition
 export const getAthleteStatsTool = {
     name: "get-athlete-stats",
     description: "Fetches the activity statistics (recent, YTD, all-time) for a specific athlete using their ID. Requires the athleteId obtained from the get-athlete-profile tool.",
@@ -146,14 +110,3 @@ export const getAthleteStatsTool = {
         }
     }
 };
-
-// Removed old registration function
-/*
-export function registerGetAthleteStatsTool(server: McpServer) {
-    server.tool(
-        getAthleteStats.name,
-        getAthleteStats.description,
-        getAthleteStats.execute // No input schema
-    );
-}
-*/ 


### PR DESCRIPTION
Restores swim stats and `biggest_climb_elevation_gain` to the `get-athlete-stats` tool output, and removes dead commented-out code from both tool files.

## Background

The original `formatStats` in `7a2e247` covered all three activity types and both record fields. During a refactor in `176ea6e`, swims and `biggest_climb_elevation_gain` were dropped and several functions were commented out rather than removed.

## Changes

- **`getAthleteStats`**: Deduplicate formatting for rides, runs, and swims. Restore `biggest_climb_elevation_gain` to output. Remove commented-out dead code.
- **`getAthleteProfile`**: Remove commented-out `registerGetAthleteProfileTool` block.
