### PR TITLE
Return ISO 8601 start times

### DIFF
--- a/src/tools/getActivityDetails.ts
+++ b/src/tools/getActivityDetails.ts
@@ -51,7 +51,7 @@ function formatPace(mps: number | null | undefined): string {
 
 // Format activity details (Metric Only)
 function formatActivityDetails(activity: StravaDetailedActivity): string {
-    const date = new Date(activity.start_date_local).toLocaleString();
+    const date = activity.start_date ?? 'N/A';
     const movingTime = formatDuration(activity.moving_time);
     const elapsedTime = formatDuration(activity.elapsed_time);
     const distance = formatDistance(activity.distance);
@@ -59,7 +59,7 @@ function formatActivityDetails(activity: StravaDetailedActivity): string {
     const avgSpeed = formatSpeed(activity.average_speed);
     const maxSpeed = formatSpeed(activity.max_speed);
     const avgPace = formatPace(activity.average_speed); // Calculate pace from speed
-    
+
     let details = `🏃 **${activity.name}** (ID: ${activity.id})\n`;
     details += `   - Type: ${activity.type} (${activity.sport_type})\n`;
     details += `   - Date: ${date}\n`;

--- a/src/tools/getAllActivities.ts
+++ b/src/tools/getAllActivities.ts
@@ -62,7 +62,7 @@ type GetAllActivitiesInput = z.infer<typeof GetAllActivitiesInputSchema>;
 
 // Helper function to format activity summary
 function formatActivitySummary(activity: any): string {
-    const date = activity.start_date ? new Date(activity.start_date).toLocaleDateString() : 'N/A';
+    const date = activity.start_date ?? 'N/A';
     const distance = activity.distance ? `${(activity.distance / 1000).toFixed(2)} km` : 'N/A';
     const duration = activity.moving_time ? formatDuration(activity.moving_time) : 'N/A';
     const type = activity.sport_type || activity.type || 'Unknown';

--- a/src/tools/getRecentActivities.ts
+++ b/src/tools/getRecentActivities.ts
@@ -43,7 +43,7 @@ export const getRecentActivities = {
 
         // Map to content items with literal type
         const contentItems = activities.map(activity => {
-          const dateStr = activity.start_date ? new Date(activity.start_date).toLocaleDateString() : 'N/A';
+          const dateStr = activity.start_date ?? 'N/A';
           const distanceStr = activity.distance ? `${activity.distance}m` : 'N/A';
           // Ensure each item conforms to { type: "text", text: string }
           const item: { type: "text", text: string } = {

--- a/src/tools/getSegmentEffort.ts
+++ b/src/tools/getSegmentEffort.ts
@@ -43,7 +43,7 @@ function formatSegmentEffort(effort: StravaDetailedSegmentEffort): string {
     let details = `⏱️ **Segment Effort: ${effort.name}** (ID: ${effort.id})\n`;
     details += `   - Activity ID: ${effort.activity.id}, Athlete ID: ${effort.athlete.id}\n`;
     details += `   - Segment ID: ${effort.segment.id}\n`;
-    details += `   - Date: ${new Date(effort.start_date_local).toLocaleString()}\n`;
+    details += `   - Date: ${effort.start_date ?? 'N/A'}\n`;
     details += `   - Moving Time: ${movingTime}, Elapsed Time: ${elapsedTime}\n`;
     if (effort.distance !== undefined) details += `   - Distance: ${distance}\n`;
     // Remove speed/pace display lines

--- a/src/tools/listSegmentEfforts.ts
+++ b/src/tools/listSegmentEfforts.ts
@@ -43,7 +43,8 @@ function formatSegmentEffort(effort: StravaDetailedSegmentEffort): string {
     const distance = formatDistance(effort.distance);
 
     // Basic summary: Effort ID, Date, Moving Time, Distance, PR Rank
-    let summary = `⏱️ Effort ID: ${effort.id} (${new Date(effort.start_date_local).toLocaleDateString()})`;
+    const dateStr = effort.start_date ?? 'N/A';
+    let summary = `⏱️ Effort ID: ${effort.id} (${dateStr})`;
     summary += ` | Time: ${movingTime} (Moving), ${elapsedTime} (Elapsed)`;
     summary += ` | Dist: ${distance}`;
     if (effort.pr_rank !== null) summary += ` | PR Rank: ${effort.pr_rank}`;


### PR DESCRIPTION
I've found that the MCP does a double TZ conversion leading to wrong start times.
The easiest fix would be to return the ISO 8601 timestamp and let the model convert to local times.


> Only use start_date (UTC). Strava's start_date_local has a misleading  'Z' suffix that causes double timezone conversion when parsed with new Date().
See: https://developers.strava.com/docs/reference/#api-Activities-getActivityById