### PR TITLE
feat: add activity update tool

### DIFF
--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -6,7 +6,9 @@ import { saveConfig, loadConfig, saveClientCredentials, hasClientCredentials, cl
 
 const PORT = 8111;
 const REDIRECT_URI = `http://localhost:${PORT}/callback`;
-const REQUIRED_SCOPES = 'profile:read_all,activity:read_all,activity:read,profile:write';
+// Used to build the Strava OAuth URL. Keep it aligned with what the MCP tools require.
+// `update-activity` needs `activity:write`.
+const REQUIRED_SCOPES = 'profile:read_all,activity:read_all,activity:read,profile:write,activity:write';
 
 export interface AuthResult {
     success: boolean;

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,6 +31,7 @@ import { getActivityPhotosTool } from './tools/getActivityPhotos.js';
 import { getServerVersionTool } from "./tools/getServerVersion.js";
 import { connectStravaTool, disconnectStravaTool, checkStravaConnectionTool } from './tools/connectStrava.js';
 import { getSegmentLeaderboardTool } from './tools/getSegmentLeaderboard.js';
+import { updateActivityTool } from './tools/updateActivity.js';
 import { loadConfig } from './config.js';
 
 // Import the actual client function
@@ -192,6 +193,14 @@ server.tool(
     getActivityPhotosTool.description,
     getActivityPhotosTool.inputSchema?.shape ?? {},
     getActivityPhotosTool.execute
+);
+
+// --- Register update-activity tool ---
+server.tool(
+    updateActivityTool.name,
+    updateActivityTool.description,
+    updateActivityTool.inputSchema?.shape ?? {},
+    updateActivityTool.execute
 );
 
 // --- Register get-server-version tool ---

--- a/src/stravaClient.ts
+++ b/src/stravaClient.ts
@@ -880,6 +880,71 @@ export async function starSegment(accessToken: string, segmentId: number, starre
 }
 
 /**
+ * Updates an activity fields (name/description/commute).
+ *
+ * MCP clients often send numeric/boolean values as strings. The tool layer handles the coercion.
+ */
+export async function updateActivity(
+    accessToken: string,
+    activityId: number,
+    payload: {
+        name?: string;
+        description?: string;
+        commute?: boolean;
+    }
+): Promise<StravaDetailedActivity> {
+    if (!accessToken) {
+        throw new Error("Strava access token is required.");
+    }
+    if (!activityId) {
+        throw new Error("Activity ID is required to update details.");
+    }
+    if (!payload || typeof payload !== "object") {
+        throw new Error("Update payload is required.");
+    }
+
+    const hasAtLeastOneField =
+        Object.prototype.hasOwnProperty.call(payload, "name") ||
+        Object.prototype.hasOwnProperty.call(payload, "description") ||
+        Object.prototype.hasOwnProperty.call(payload, "commute");
+
+    if (!hasAtLeastOneField) {
+        throw new Error("Update payload must contain at least one of: name, description, commute.");
+    }
+
+    try {
+        const response = await stravaApi.put<unknown>(
+            `activities/${activityId}`,
+            payload,
+            {
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                    "Content-Type": "application/json",
+                },
+            }
+        );
+
+        const validationResult = DetailedActivitySchema.safeParse(response.data);
+
+        if (!validationResult.success) {
+            console.error(`Strava API validation failed (updateActivity: ${activityId}):`, validationResult.error);
+            throw new Error(`Invalid data format received from Strava API: ${validationResult.error.message}`);
+        }
+
+        return validationResult.data;
+    } catch (error) {
+        return await handleApiError<StravaDetailedActivity>(
+            error,
+            `updateActivity for ID ${activityId}`,
+            async () => {
+                const newToken = process.env.STRAVA_ACCESS_TOKEN!;
+                return updateActivity(newToken, activityId, payload);
+            }
+        );
+    }
+}
+
+/**
  * Fetches detailed information about a specific segment effort by its ID.
  *
  * @param accessToken - The Strava API access token.

--- a/src/tools/updateActivity.ts
+++ b/src/tools/updateActivity.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+import { updateActivity as updateActivityClient, StravaDetailedActivity } from "../stravaClient.js";
+import { formatLocalDateTime } from "../formatters.js";
+
+const ActivityIdSchema = z
+    .union([z.number().int().positive(), z.string().regex(/^\d+$/)])
+    .transform((val) => (typeof val === "number" ? val : parseInt(val, 10)))
+    .refine((n) => Number.isInteger(n) && n > 0, { message: "Invalid Strava activity id" })
+    .describe("The Strava activity id (integer). Numeric strings are accepted.");
+
+const CommuteSchema = z
+    .union([z.boolean(), z.string().regex(/^(true|false)$/)])
+    .transform((val) => (typeof val === "boolean" ? val : val === "true"));
+
+const inputSchema = z.object({
+    activityId: ActivityIdSchema,
+    name: z.string().optional().describe("New name of the activity."),
+    description: z.string().optional().describe("New description of the activity."),
+    commute: CommuteSchema.optional().describe("Whether the activity is a commute."),
+});
+
+type UpdateActivityInput = z.infer<typeof inputSchema>;
+
+function formatUpdatedActivity(activity: StravaDetailedActivity, sent: { name?: string; description?: string; commute?: boolean }): string {
+    const date = activity.start_date_local ? formatLocalDateTime(activity.start_date_local) : "N/A";
+    const parts: string[] = [];
+    parts.push(`Activity updated (ID: ${activity.id})`);
+    parts.push(`   - Date: ${date}`);
+    if (sent.name !== undefined) {
+        parts.push(`   - Name: ${activity.name}`);
+    }
+    if (sent.description !== undefined) {
+        parts.push(`   - Description updated.`);
+    }
+    if (sent.commute !== undefined) {
+        parts.push(`   - Commute: ${activity.commute ? "true" : "false"}`);
+    }
+
+    return parts.join("\n");
+}
+
+export const updateActivityTool = {
+    name: "update-activity",
+    description: "Update a Strava activity name, description, and/or commute flag.",
+    inputSchema,
+    execute: async ({ activityId, name, description, commute }: UpdateActivityInput) => {
+        const token = process.env.STRAVA_ACCESS_TOKEN;
+
+        if (!token) {
+            console.error("Missing STRAVA_ACCESS_TOKEN environment variable.");
+            return {
+                content: [{ type: "text" as const, text: "Configuration error: Missing Strava access token." }],
+                isError: true,
+            };
+        }
+
+        try {
+            console.error(`Updating activity ID: ${activityId}...`);
+
+            const payload: { name?: string; description?: string; commute?: boolean } = {};
+            if (name !== undefined) payload.name = name;
+            if (description !== undefined) payload.description = description;
+            if (commute !== undefined) payload.commute = commute;
+
+            const updated = await updateActivityClient(token, activityId, payload);
+
+            console.error(`Successfully updated activity ${activityId}.`);
+            return {
+                content: [{ type: "text" as const, text: formatUpdatedActivity(updated, { name, description, commute }) }],
+            };
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            console.error(`Error updating activity ${activityId}: ${errorMessage}`);
+
+            const userFriendlyMessage =
+                errorMessage.startsWith("SUBSCRIPTION_REQUIRED:")
+                    ? `Accessing this action requires a Strava subscription.`
+                    : errorMessage.includes("Record Not Found") || errorMessage.includes("404")
+                        ? `Activity with ID ${activityId} not found.`
+                        : `An unexpected error occurred while updating activity details for ID ${activityId}. Details: ${errorMessage}`;
+
+            return {
+                content: [{ type: "text" as const, text: `❌ ${userFriendlyMessage}` }],
+                isError: true,
+            };
+        }
+    },
+};
+

--- a/tests/updateActivity.tool.test.ts
+++ b/tests/updateActivity.tool.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { updateActivityTool } from "../src/tools/updateActivity.js";
+import { updateActivity as updateActivityClient } from "../src/stravaClient.js";
+
+vi.mock("../src/stravaClient.js", () => ({
+    updateActivity: vi.fn(),
+}));
+
+describe("update-activity tool", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        process.env.STRAVA_ACCESS_TOKEN = "test-token";
+    });
+
+    it("accepts activityId as string + commute as string (Claude/Cowork pattern)", async () => {
+        vi.mocked(updateActivityClient).mockResolvedValue({
+            id: 123,
+            name: "New name",
+            start_date_local: "2024-01-01T00:00:00Z",
+            commute: false,
+        } as any);
+
+        const args = updateActivityTool.inputSchema.parse({
+            activityId: "123",
+            name: "New name",
+            description: "New description",
+            commute: "false",
+        });
+
+        const result = await updateActivityTool.execute(args);
+
+        expect(updateActivityClient).toHaveBeenCalledWith("test-token", 123, {
+            name: "New name",
+            description: "New description",
+            commute: false,
+        });
+        expect(result.isError).toBeUndefined();
+        expect(result.content[0].text).toContain("Activity updated");
+        expect(result.content[0].text).toContain("Commute: false");
+    });
+
+    it("returns config error when token is missing", async () => {
+        delete process.env.STRAVA_ACCESS_TOKEN;
+
+        const args = updateActivityTool.inputSchema.parse({
+            activityId: 1,
+            commute: false,
+        });
+
+        const result = await updateActivityTool.execute(args);
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("Missing Strava access token");
+    });
+});
+


### PR DESCRIPTION
## Summary
- Add a new `update-activity` MCP tool to update Strava activity fields (`name`, `description`, `commute`) via `PUT /activities/{id}`
- Handle MCP client string coercion (activityId as string, commute as "true"/"false") using `z.union().transform().refine()` for JSON Schema `anyOf` compatibility with strict clients (Claude, Cowork)
- Add `activity:write` to OAuth required scopes

## Changes
| File | Description |
|---|---|
| `src/tools/updateActivity.ts` | New tool definition with input schema, formatter, error handling |
| `src/stravaClient.ts` | New `updateActivity()` function with API validation and token refresh |
| `src/server.ts` | Import and register the new tool |
| `src/auth/server.ts` | Add `activity:write` to `REQUIRED_SCOPES` |
| `tests/updateActivity.tool.test.ts` | Unit tests (string coercion, missing token) |

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 71/71 tests pass
- [x] Manual test validated locally