### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ A browser window will open. Enter your Strava API credentials, authorize the app
 
 ---
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/r-huijts-strava-mcp).
+
 ## Connecting Your Strava Account
 
 ### First Time Setup


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/r-huijts-strava-mcp).