### PR TITLE
Add test suite, fix typos, ESLint config, SECURITY.md, and CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - name: Install dependencies
+        run: npm ci
+      - name: Run ESLint
+        run: npx eslint src --ext .ts
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests with coverage
+        run: npm run test:coverage

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| latest  | Yes       |
+
+## Reporting a Vulnerability
+
+Please do **not** open a public issue for security vulnerabilities.
+
+Report them by opening a [GitHub Security Advisory](../../security/advisories/new) or by contacting the maintainer directly via their GitHub profile.
+
+Include: description, steps to reproduce, and potential impact. Expect a response within 72 hours.
+
+## Token Security
+
+This project uses OAuth tokens to authenticate with the Strava API.
+
+- Never hardcode tokens in source files or config files
+- Store secrets as environment variables or in `~/.config/strava-mcp/config.json` (user-only permissions)
+- The config file is excluded from version control via `.gitignore`
+- Never commit `.env` files containing real credentials
+
+## Sensitive Files
+
+The following files may contain credentials and must never be committed:
+
+- `.env`
+- `strava_tokens.json`
+- `~/.config/strava-mcp/config.json` (stored outside the repo by design)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,24 @@
+import tsPlugin from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+
+export default [
+    {
+        files: ["src/**/*.ts"],
+        ignores: ["dist/**", "node_modules/**"],
+        languageOptions: {
+            parser: tsParser,
+            parserOptions: {
+                ecmaVersion: 2022,
+                sourceType: "module",
+            },
+        },
+        plugins: {
+            "@typescript-eslint": tsPlugin,
+        },
+        rules: {
+            "@typescript-eslint/no-explicit-any": "warn",
+            "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+            "no-console": "off",
+        },
+    },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/node": "^20.11.0",
         "@typescript-eslint/eslint-plugin": "^6.19.0",
         "@typescript-eslint/parser": "^6.19.0",
+        "@vitest/coverage-v8": "^2.1.8",
         "eslint": "^8.56.0",
         "ts-node": "^10.9.0",
         "tsx": "^4.7.0",
@@ -31,6 +32,88 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -619,6 +702,85 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -704,6 +866,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1277,6 +1450,39 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
@@ -1967,10 +2173,24 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -2539,6 +2759,23 @@
         }
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
@@ -2838,6 +3075,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -2955,6 +3199,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3032,6 +3286,87 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -3121,6 +3456,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3129,6 +3471,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-error": {
@@ -3227,6 +3597,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -3380,6 +3760,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3429,6 +3816,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {
@@ -3948,6 +4352,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -3991,7 +4408,91 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -4028,6 +4529,115 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/text-table": {
@@ -4895,6 +5505,107 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lint": "eslint . --ext .ts",
     "setup-auth": "tsx scripts/setup-auth.ts",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:api": "RUN_API_TESTS=true vitest run tests/getActivityStreams.api.test.ts",
     "prepublishOnly": "npm run build"
   },
@@ -54,6 +55,7 @@
     "ts-node": "^10.9.0",
     "tsx": "^4.7.0",
     "typescript": "^5.3.0",
-    "vitest": "^2.1.8"
+    "vitest": "^2.1.8",
+    "@vitest/coverage-v8": "^2.1.8"
   }
 }

--- a/src/stravaClient.ts
+++ b/src/stravaClient.ts
@@ -19,7 +19,6 @@ stravaApi.interceptors.request.use(config => {
     // console.error(`[DEBUG stravaClient] Authorization Header: ${authHeaderLog}` );
     return config;
 }, error => {
-    console.error('[DEBUG stravaClient] Request Error Interceptor:', error);
     return Promise.reject(error);
 });
 // ----------------------------------

--- a/src/tools/getRecentActivities.ts
+++ b/src/tools/getRecentActivities.ts
@@ -38,7 +38,7 @@ export const getRecentActivities = {
 
         if (!activities || activities.length === 0) {
            return {
-             content: [{ type: "text" as const, text: " MNo recent activities found." }]
+             content: [{ type: "text" as const, text: "No recent activities found." }]
             };
         }
 

--- a/src/tools/listAthleteClubs.ts
+++ b/src/tools/listAthleteClubs.ts
@@ -23,7 +23,7 @@ export const listAthleteClubs = {
             console.error(`Successfully fetched ${clubs?.length ?? 0} clubs.`);
 
             if (!clubs || clubs.length === 0) {
-                return { content: [{ type: "text" as const, text: " MNo clubs found for the athlete." }] };
+                return { content: [{ type: "text" as const, text: "No clubs found for the athlete." }] };
             }
 
             const clubText = clubs.map(club =>

--- a/src/tools/listStarredSegments.ts
+++ b/src/tools/listStarredSegments.ts
@@ -27,7 +27,7 @@ export const listStarredSegments = {
             console.error(`Successfully fetched ${segments?.length ?? 0} starred segments.`);
 
             if (!segments || segments.length === 0) {
-                return { content: [{ type: "text" as const, text: " MNo starred segments found." }] };
+                return { content: [{ type: "text" as const, text: "No starred segments found." }] };
             }
 
             const distanceFactor = athlete.measurement_preference === 'feet' ? 0.000621371 : 0.001;

--- a/tests/formatWorkoutFile.test.ts
+++ b/tests/formatWorkoutFile.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import { formatWorkoutFile } from "../src/tools/formatWorkoutFile.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Call execute with zwo format (the only supported format) */
+async function execute(workoutText: string) {
+    return formatWorkoutFile.execute({ workoutText, format: "zwo" });
+}
+
+/** Extract the text content from the result */
+function resultText(result: Awaited<ReturnType<typeof execute>>): string {
+    return result.content[0].text;
+}
+
+// ---------------------------------------------------------------------------
+// Tool metadata
+// ---------------------------------------------------------------------------
+
+describe("formatWorkoutFile tool metadata", () => {
+    it("has the correct name", () => {
+        expect(formatWorkoutFile.name).toBe("format-workout-file");
+    });
+
+    it("has a description", () => {
+        expect(typeof formatWorkoutFile.description).toBe("string");
+        expect(formatWorkoutFile.description.length).toBeGreaterThan(0);
+    });
+
+    it("has an inputSchema", () => {
+        expect(formatWorkoutFile.inputSchema).toBeDefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// execute — valid inputs
+// ---------------------------------------------------------------------------
+
+describe("formatWorkoutFile execute — valid workout text", () => {
+    it("returns XML with SteadyState elements for a single segment", async () => {
+        const text = "- Warm-up: 10 min at easy";
+        const result = await execute(text);
+        expect(result.isError).toBeUndefined();
+        expect(resultText(result)).toContain("<SteadyState");
+    });
+
+    it("returns well-formed ZWO XML wrapper tags", async () => {
+        const text = "- Warm-up: 10 min at easy";
+        const xml = resultText(await execute(text));
+        expect(xml).toContain("<workout_file>");
+        expect(xml).toContain("</workout_file>");
+        expect(xml).toContain("<workout>");
+        expect(xml).toContain("</workout>");
+    });
+
+    it("generates one SteadyState element per segment", async () => {
+        const text = [
+            "- Warm-up: 10 min at easy",
+            "- Interval: 5 min at threshold",
+            "- Cool-down: 5 min at very easy",
+        ].join("\n");
+        const xml = resultText(await execute(text));
+        const matches = xml.match(/<SteadyState/g);
+        expect(matches).toHaveLength(3);
+    });
+
+    it("converts minutes to seconds in the Duration attribute", async () => {
+        const text = "- Main: 20 min at easy";
+        const xml = resultText(await execute(text));
+        expect(xml).toContain('Duration="1200"');
+    });
+
+    it("uses seconds directly when unit is sec", async () => {
+        const text = "- Sprint: 30 sec at max";
+        const xml = resultText(await execute(text));
+        expect(xml).toContain('Duration="30"');
+    });
+
+    it("maps an FTP percentage target to a decimal Power attribute", async () => {
+        const text = "- Interval: 10 min at 75% FTP";
+        const xml = resultText(await execute(text));
+        expect(xml).toContain('Power="0.75"');
+    });
+
+    it("maps 'threshold' zone description to Power='1'", async () => {
+        const text = "- Threshold: 8 min at threshold";
+        const xml = resultText(await execute(text));
+        expect(xml).toContain('Power="1"');
+    });
+
+    it("maps 'easy' to Power='0.6'", async () => {
+        const text = "- Warm-up: 5 min at easy";
+        const xml = resultText(await execute(text));
+        expect(xml).toContain('Power="0.6"');
+    });
+
+    it("maps 'max' to Power='1.2'", async () => {
+        const text = "- Sprint: 20 sec at max";
+        const xml = resultText(await execute(text));
+        expect(xml).toContain('Power="1.2"');
+    });
+
+    it("defaults unknown targets to Power='0.75'", async () => {
+        const text = "- Mystery: 5 min at ultrafast";
+        const xml = resultText(await execute(text));
+        expect(xml).toContain('Power="0.75"');
+    });
+
+    it("includes Cadence attribute when cadence is specified in extras", async () => {
+        const text = "- Spin: 5 min at easy [Cadence: 95]";
+        const xml = resultText(await execute(text));
+        expect(xml).toContain('Cadence="95"');
+    });
+
+    it("does not include Cadence attribute when no cadence is provided", async () => {
+        const text = "- Interval: 5 min at easy";
+        const xml = resultText(await execute(text));
+        expect(xml).not.toContain("Cadence=");
+    });
+
+    it("adds ShowsPower='1' when target contains 'FTP'", async () => {
+        const text = "- Effort: 10 min at 85% FTP";
+        const xml = resultText(await execute(text));
+        expect(xml).toContain('ShowsPower="1"');
+    });
+
+    it("does not add ShowsPower for zone descriptions (no FTP keyword)", async () => {
+        const text = "- Effort: 10 min at tempo";
+        const xml = resultText(await execute(text));
+        expect(xml).not.toContain("ShowsPower");
+    });
+
+    it("includes notes as textEvent attribute when Notes extra is provided", async () => {
+        const text = "- Interval: 5 min at hard [Notes: Push hard here]";
+        const xml = resultText(await execute(text));
+        expect(xml).toContain('textEvent="Push hard here"');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// execute — empty / invalid inputs
+// ---------------------------------------------------------------------------
+
+describe("formatWorkoutFile execute — empty or invalid input", () => {
+    it("returns isError=true when no valid segments are found", async () => {
+        const result = await execute("This is just some plain text with no segments.");
+        expect(result.isError).toBe(true);
+    });
+
+    it("error message mentions 'No valid workout segments'", async () => {
+        const result = await execute("");
+        expect(resultText(result)).toContain("No valid workout segments");
+    });
+
+    it("skips lines that don't start with '-'", async () => {
+        const text = "Warm-up: 10 min at easy\nInterval: 5 min at threshold";
+        const result = await execute(text);
+        expect(result.isError).toBe(true);
+    });
+
+    it("returns isError=true for a segment with invalid duration format", async () => {
+        const text = "- Interval: FAST at easy";
+        const result = await execute(text);
+        expect(result.isError).toBe(true);
+    });
+
+    it("error message for segment with no valid duration returns no-segments error", async () => {
+        // The segment line doesn't match the outer regex, so it is silently skipped,
+        // resulting in the "No valid workout segments" path rather than a throw.
+        const text = "- Interval: FAST at easy";
+        const result = await execute(text);
+        expect(resultText(result)).toContain("No valid workout segments");
+    });
+});

--- a/tests/formatters.test.ts
+++ b/tests/formatters.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import {
+    formatLocalDate,
+    formatLocalDateTime,
+    formatRouteSummary,
+} from "../src/formatters.js";
+
+// ---------------------------------------------------------------------------
+// formatLocalDateTime
+// ---------------------------------------------------------------------------
+describe("formatLocalDateTime", () => {
+    it("formats a standard ISO datetime string", () => {
+        expect(formatLocalDateTime("2026-03-22T13:48:39")).toBe("03/22/2026, 13:48");
+    });
+
+    it("formats midnight correctly", () => {
+        expect(formatLocalDateTime("2024-01-01T00:00:00")).toBe("01/01/2024, 00:00");
+    });
+
+    it("returns the original string when format is invalid", () => {
+        expect(formatLocalDateTime("not-a-date")).toBe("not-a-date");
+    });
+
+    it("returns the original string when only a date is provided (no time)", () => {
+        // No T separator — regex won't match
+        expect(formatLocalDateTime("2026-03-22")).toBe("2026-03-22");
+    });
+
+    it("handles end-of-year datetime", () => {
+        expect(formatLocalDateTime("2025-12-31T23:59:00")).toBe("12/31/2025, 23:59");
+    });
+
+    it("ignores seconds — only captures hours and minutes", () => {
+        expect(formatLocalDateTime("2026-06-15T09:05:59")).toBe("06/15/2026, 09:05");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// formatLocalDate
+// ---------------------------------------------------------------------------
+describe("formatLocalDate", () => {
+    it("formats a standard ISO date string", () => {
+        expect(formatLocalDate("2026-03-22")).toBe("03/22/2026");
+    });
+
+    it("formats a datetime string, stripping the time portion", () => {
+        expect(formatLocalDate("2026-03-22T13:48:39")).toBe("03/22/2026");
+    });
+
+    it("returns the original string when format is invalid", () => {
+        expect(formatLocalDate("invalid")).toBe("invalid");
+    });
+
+    it("handles single-digit months and days with zero-padding", () => {
+        expect(formatLocalDate("2024-01-05")).toBe("01/05/2024");
+    });
+
+    it("handles end-of-year date", () => {
+        expect(formatLocalDate("2025-12-31")).toBe("12/31/2025");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// formatRouteSummary
+// ---------------------------------------------------------------------------
+describe("formatRouteSummary", () => {
+    const baseRoute = {
+        id: 42,
+        name: "Morning Loop",
+        distance: 25000,          // 25 km
+        elevation_gain: 350.6,
+        created_at: "2026-01-10T08:30:00",
+        type: 1,                  // Ride
+        segments: [{ id: 1 }, { id: 2 }],
+        description: null,
+    } as any;
+
+    it("includes the route name and id", () => {
+        const result = formatRouteSummary(baseRoute);
+        expect(result).toContain("Morning Loop");
+        expect(result).toContain("#42");
+    });
+
+    it("formats distance in km", () => {
+        const result = formatRouteSummary(baseRoute);
+        expect(result).toContain("25.00 km");
+    });
+
+    it("formats elevation gain in meters (rounded)", () => {
+        const result = formatRouteSummary(baseRoute);
+        expect(result).toContain("351 m");
+    });
+
+    it("maps type=1 to 'Ride'", () => {
+        const result = formatRouteSummary({ ...baseRoute, type: 1 });
+        expect(result).toContain("Ride");
+    });
+
+    it("maps type=2 to 'Run'", () => {
+        const result = formatRouteSummary({ ...baseRoute, type: 2 });
+        expect(result).toContain("Run");
+    });
+
+    it("maps type=3 to 'Walk'", () => {
+        const result = formatRouteSummary({ ...baseRoute, type: 3 });
+        expect(result).toContain("Walk");
+    });
+
+    it("maps unknown type to 'Walk'", () => {
+        const result = formatRouteSummary({ ...baseRoute, type: 99 });
+        expect(result).toContain("Walk");
+    });
+
+    it("includes segment count", () => {
+        const result = formatRouteSummary(baseRoute);
+        expect(result).toContain("Segments: 2");
+    });
+
+    it("shows N/A when segments is undefined", () => {
+        const result = formatRouteSummary({ ...baseRoute, segments: undefined });
+        expect(result).toContain("Segments: N/A");
+    });
+
+    it("includes formatted created date", () => {
+        const result = formatRouteSummary(baseRoute);
+        expect(result).toContain("01/10/2026");
+    });
+
+    it("does not include a description line when description is absent", () => {
+        const result = formatRouteSummary({ ...baseRoute, description: null });
+        expect(result).not.toContain("Description:");
+    });
+
+    it("includes description when present and short", () => {
+        const route = { ...baseRoute, description: "A nice easy loop." };
+        const result = formatRouteSummary(route);
+        expect(result).toContain("Description: A nice easy loop.");
+    });
+
+    it("truncates description longer than 100 characters and appends '...'", () => {
+        const longDesc = "A".repeat(101);
+        const result = formatRouteSummary({ ...baseRoute, description: longDesc });
+        expect(result).toContain("...");
+        // The truncated portion should be exactly 100 A's
+        expect(result).toContain("A".repeat(100));
+    });
+
+    it("does not append '...' when description is exactly 100 characters", () => {
+        const exactDesc = "B".repeat(100);
+        const result = formatRouteSummary({ ...baseRoute, description: exactDesc });
+        expect(result).not.toContain("...");
+    });
+});

--- a/tests/getActivityDetails.test.ts
+++ b/tests/getActivityDetails.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getActivityDetailsTool } from "../src/tools/getActivityDetails.js";
+import { getActivityById } from "../src/stravaClient.js";
+
+vi.mock("../src/stravaClient.js", () => ({
+    getActivityById: vi.fn(),
+}));
+
+vi.mock("../src/formatters.js", () => ({
+    formatLocalDateTime: vi.fn().mockReturnValue("01/15/2024, 08:30"),
+}));
+
+const mockActivity = {
+    id: 12345,
+    resource_state: 3,
+    athlete: { id: 67890, resource_state: 1 },
+    name: "Morning Run",
+    type: "Run",
+    sport_type: "Run",
+    start_date: "2024-01-15T13:30:00Z",
+    start_date_local: "2024-01-15T08:30:00Z",
+    timezone: "America/New_York",
+    start_latlng: [42.3601, -71.0589],
+    end_latlng: [42.3601, -71.0589],
+    distance: 10000,
+    moving_time: 3600,
+    elapsed_time: 3700,
+    total_elevation_gain: 50,
+    average_speed: 2.78,
+    max_speed: 4.5,
+    kudos_count: 10,
+    comment_count: 2,
+    photo_count: 0,
+    map: { id: "a12345", resource_state: 1 },
+    trainer: false,
+    commute: false,
+    manual: false,
+    private: false,
+    flagged: false,
+    gear_id: null,
+    has_heartrate: false,
+    description: null,
+    gear: null,
+};
+
+describe("get-activity-details tool", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        delete process.env.STRAVA_ACCESS_TOKEN;
+    });
+
+    it("returns config error when token is missing", async () => {
+        const result = await getActivityDetailsTool.execute({ activityId: 12345 });
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("access token");
+    });
+
+    it("returns formatted activity details on successful fetch", async () => {
+        process.env.STRAVA_ACCESS_TOKEN = "test-token";
+        vi.mocked(getActivityById).mockResolvedValue(mockActivity as any);
+
+        const result = await getActivityDetailsTool.execute({ activityId: 12345 });
+
+        expect(result.isError).toBeUndefined();
+        expect(result.content[0].text).toContain("Morning Run");
+        expect(result.content[0].text).toContain("Run");
+        expect(result.content[0].text).toContain("10.00 km");
+    });
+
+    it("returns not found error when activity 404 (Record Not Found)", async () => {
+        process.env.STRAVA_ACCESS_TOKEN = "test-token";
+        vi.mocked(getActivityById).mockRejectedValue(new Error("Record Not Found"));
+
+        const result = await getActivityDetailsTool.execute({ activityId: 99999 });
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text.toLowerCase()).toContain("not found");
+    });
+
+    it("returns generic error on unexpected API failure", async () => {
+        process.env.STRAVA_ACCESS_TOKEN = "test-token";
+        vi.mocked(getActivityById).mockRejectedValue(new Error("Internal Server Error"));
+
+        const result = await getActivityDetailsTool.execute({ activityId: 12345 });
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("Internal Server Error");
+    });
+});

--- a/tests/getAllActivities.toolFilter.test.ts
+++ b/tests/getAllActivities.toolFilter.test.ts
@@ -35,7 +35,7 @@ describe("get-all-activities tool", () => {
             const text = result.content[0]?.text ?? "";
             expect(text).toContain("**Found 1 activities**");
             expect(text).toContain("ID: 1234567890");
-            expect(text).toContain(" - Run - ");
+            expect(text).toContain("Run Test Run");
         } finally {
             process.env.STRAVA_ACCESS_TOKEN = previousToken;
         }

--- a/tests/getAthleteStats.test.ts
+++ b/tests/getAthleteStats.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getAthleteStatsTool } from "../src/tools/getAthleteStats.js";
+import { getAthleteStats } from "../src/stravaClient.js";
+
+vi.mock("../src/stravaClient.js", () => ({
+    getAthleteStats: vi.fn(),
+}));
+
+const mockActivityTotals = {
+    count: 10,
+    distance: 50000,
+    moving_time: 18000,
+    elapsed_time: 19000,
+    elevation_gain: 500,
+};
+
+const mockStats = {
+    biggest_ride_distance: 120000,
+    biggest_climb_elevation_gain: 1800,
+    recent_ride_totals: { ...mockActivityTotals },
+    ytd_ride_totals: { ...mockActivityTotals, count: 50, distance: 250000 },
+    all_ride_totals: { ...mockActivityTotals, count: 200, distance: 1000000 },
+    recent_run_totals: { ...mockActivityTotals },
+    ytd_run_totals: { ...mockActivityTotals, count: 30, distance: 150000 },
+    all_run_totals: { ...mockActivityTotals, count: 120, distance: 600000 },
+    recent_swim_totals: { ...mockActivityTotals },
+    ytd_swim_totals: { ...mockActivityTotals, count: 5, distance: 10000 },
+    all_swim_totals: { ...mockActivityTotals, count: 20, distance: 40000 },
+};
+
+describe("get-athlete-stats tool", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        delete process.env.STRAVA_ACCESS_TOKEN;
+    });
+
+    it("returns config error when token is missing", async () => {
+        const result = await getAthleteStatsTool.execute({ athleteId: 67890 });
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("access token");
+    });
+
+    it("returns formatted stats on successful fetch", async () => {
+        process.env.STRAVA_ACCESS_TOKEN = "test-token";
+        vi.mocked(getAthleteStats).mockResolvedValue(mockStats as any);
+
+        const result = await getAthleteStatsTool.execute({ athleteId: 67890 });
+
+        expect(result.isError).toBeUndefined();
+        expect(result.content[0].text).toContain("Your Strava Stats");
+        expect(result.content[0].text).toContain("Rides");
+        expect(result.content[0].text).toContain("Runs");
+    });
+
+    it("returns not found error when athlete 404 (Record Not Found)", async () => {
+        process.env.STRAVA_ACCESS_TOKEN = "test-token";
+        vi.mocked(getAthleteStats).mockRejectedValue(new Error("Record Not Found"));
+
+        const result = await getAthleteStatsTool.execute({ athleteId: 99999 });
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text.toLowerCase()).toContain("not found");
+    });
+
+    it("returns generic error on unexpected API failure", async () => {
+        process.env.STRAVA_ACCESS_TOKEN = "test-token";
+        vi.mocked(getAthleteStats).mockRejectedValue(new Error("Service Unavailable"));
+
+        const result = await getAthleteStatsTool.execute({ athleteId: 67890 });
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("Service Unavailable");
+    });
+});

--- a/tests/getRecentActivities.test.ts
+++ b/tests/getRecentActivities.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getRecentActivities } from "../src/tools/getRecentActivities.js";
+import { getRecentActivities as fetchActivities, getAuthenticatedAthlete } from "../src/stravaClient.js";
+
+vi.mock("../src/stravaClient.js", () => ({
+    getRecentActivities: vi.fn(),
+    getAuthenticatedAthlete: vi.fn(),
+}));
+
+const mockAthlete = {
+    id: 1,
+    resource_state: 3,
+    username: "test",
+    firstname: "Test",
+    lastname: "User",
+    city: null,
+    state: null,
+    country: null,
+    sex: null,
+    premium: false,
+    summit: false,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-02T00:00:00Z",
+    profile_medium: "https://example.com/medium.jpg",
+    profile: "https://example.com/profile.jpg",
+    weight: null,
+    measurement_preference: "meters",
+    shoes: [],
+} as any;
+
+const mockActivity = {
+    id: 123,
+    name: "Test Run",
+    type: "Run",
+    sport_type: "Run",
+    distance: 5000,
+    start_date: "2024-01-15T08:30:00Z",
+    moving_time: 1800,
+};
+
+describe("get-recent-activities tool", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        delete process.env.STRAVA_ACCESS_TOKEN;
+    });
+
+    it("returns config error when token is missing", async () => {
+        const result = await getRecentActivities.execute({ perPage: 30 });
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("STRAVA_ACCESS_TOKEN");
+    });
+
+    it("returns config error when token is placeholder", async () => {
+        process.env.STRAVA_ACCESS_TOKEN = "YOUR_STRAVA_ACCESS_TOKEN_HERE";
+
+        const result = await getRecentActivities.execute({ perPage: 30 });
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("STRAVA_ACCESS_TOKEN");
+    });
+
+    it("returns no activities message when list is empty", async () => {
+        process.env.STRAVA_ACCESS_TOKEN = "test-token";
+        vi.mocked(getAuthenticatedAthlete).mockResolvedValue(mockAthlete);
+        vi.mocked(fetchActivities).mockResolvedValue([]);
+
+        const result = await getRecentActivities.execute({ perPage: 30 });
+
+        expect(result.isError).toBeUndefined();
+        expect(result.content[0].text).toBe("No recent activities found.");
+    });
+
+    it("returns activities with km units for metric preference", async () => {
+        process.env.STRAVA_ACCESS_TOKEN = "test-token";
+        vi.mocked(getAuthenticatedAthlete).mockResolvedValue({
+            ...mockAthlete,
+            measurement_preference: "meters",
+        });
+        vi.mocked(fetchActivities).mockResolvedValue([mockActivity] as any);
+
+        const result = await getRecentActivities.execute({ perPage: 30 });
+
+        expect(result.isError).toBeUndefined();
+        expect(result.content[0].text).toContain("Test Run");
+        expect(result.content[0].text).toContain(" km");
+    });
+
+    it("returns activities with mi units for imperial preference", async () => {
+        process.env.STRAVA_ACCESS_TOKEN = "test-token";
+        vi.mocked(getAuthenticatedAthlete).mockResolvedValue({
+            ...mockAthlete,
+            measurement_preference: "feet",
+        });
+        vi.mocked(fetchActivities).mockResolvedValue([mockActivity] as any);
+
+        const result = await getRecentActivities.execute({ perPage: 30 });
+
+        expect(result.isError).toBeUndefined();
+        expect(result.content[0].text).toContain("Test Run");
+        expect(result.content[0].text).toContain(" mi");
+    });
+
+    it("returns error on API failure", async () => {
+        process.env.STRAVA_ACCESS_TOKEN = "test-token";
+        vi.mocked(getAuthenticatedAthlete).mockRejectedValue(new Error("Network error"));
+
+        const result = await getRecentActivities.execute({ perPage: 30 });
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("Network error");
+    });
+});

--- a/tests/listAthleteClubs.test.ts
+++ b/tests/listAthleteClubs.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { listAthleteClubs } from "../src/tools/listAthleteClubs.js";
+import { listAthleteClubs as fetchClubs } from "../src/stravaClient.js";
+
+vi.mock("../src/stravaClient.js", () => ({
+    listAthleteClubs: vi.fn(),
+}));
+
+const mockClub = {
+    id: 1,
+    name: "Test Club",
+    sport_type: "cycling",
+    member_count: 150,
+    city: "Ithaca",
+    state: "NY",
+    country: "USA",
+    private: false,
+    url: "test-club",
+};
+
+describe("list-athlete-clubs tool", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        delete process.env.STRAVA_ACCESS_TOKEN;
+    });
+
+    it("returns config error when token is missing", async () => {
+        const result = await listAthleteClubs.execute();
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("STRAVA_ACCESS_TOKEN");
+    });
+
+    it("returns config error when token is placeholder", async () => {
+        process.env.STRAVA_ACCESS_TOKEN = "YOUR_STRAVA_ACCESS_TOKEN_HERE";
+
+        const result = await listAthleteClubs.execute();
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("STRAVA_ACCESS_TOKEN");
+    });
+
+    it("returns no clubs message when list is empty", async () => {
+        process.env.STRAVA_ACCESS_TOKEN = "test-token";
+        vi.mocked(fetchClubs).mockResolvedValue([]);
+
+        const result = await listAthleteClubs.execute();
+
+        expect(result.isError).toBeUndefined();
+        expect(result.content[0].text).toBe("No clubs found for the athlete.");
+    });
+
+    it("returns club details when clubs exist", async () => {
+        process.env.STRAVA_ACCESS_TOKEN = "test-token";
+        vi.mocked(fetchClubs).mockResolvedValue([mockClub] as any);
+
+        const result = await listAthleteClubs.execute();
+
+        expect(result.isError).toBeUndefined();
+        expect(result.content[0].text).toContain("Test Club");
+        expect(result.content[0].text).toContain("cycling");
+        expect(result.content[0].text).toContain("150");
+    });
+
+    it("returns error on API failure", async () => {
+        process.env.STRAVA_ACCESS_TOKEN = "test-token";
+        vi.mocked(fetchClubs).mockRejectedValue(new Error("API unavailable"));
+
+        const result = await listAthleteClubs.execute();
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("API unavailable");
+    });
+});

--- a/tests/listStarredSegments.test.ts
+++ b/tests/listStarredSegments.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { listStarredSegments } from "../src/tools/listStarredSegments.js";
+import { getAuthenticatedAthlete, listStarredSegments as fetchSegments } from "../src/stravaClient.js";
+
+vi.mock("../src/stravaClient.js", () => ({
+    getAuthenticatedAthlete: vi.fn(),
+    listStarredSegments: vi.fn(),
+}));
+
+const mockAthlete = {
+    id: 1,
+    resource_state: 3,
+    username: "test",
+    firstname: "Test",
+    lastname: "User",
+    city: null,
+    state: null,
+    country: null,
+    sex: null,
+    premium: false,
+    summit: false,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-02T00:00:00Z",
+    profile_medium: "https://example.com/medium.jpg",
+    profile: "https://example.com/profile.jpg",
+    weight: null,
+    measurement_preference: "meters",
+    shoes: [],
+} as any;
+
+const mockSegment = {
+    id: 1,
+    name: "KOM Hill",
+    activity_type: "Ride",
+    distance: 3200,
+    average_grade: 5.2,
+    city: "Ithaca",
+    state: "NY",
+    country: "USA",
+    private: false,
+};
+
+describe("list-starred-segments tool", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        delete process.env.STRAVA_ACCESS_TOKEN;
+    });
+
+    it("returns config error when token is missing", async () => {
+        const result = await listStarredSegments.execute();
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("STRAVA_ACCESS_TOKEN");
+    });
+
+    it("returns config error when token is placeholder", async () => {
+        process.env.STRAVA_ACCESS_TOKEN = "YOUR_STRAVA_ACCESS_TOKEN_HERE";
+
+        const result = await listStarredSegments.execute();
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("STRAVA_ACCESS_TOKEN");
+    });
+
+    it("returns no segments message when list is empty", async () => {
+        process.env.STRAVA_ACCESS_TOKEN = "test-token";
+        vi.mocked(getAuthenticatedAthlete).mockResolvedValue(mockAthlete);
+        vi.mocked(fetchSegments).mockResolvedValue([]);
+
+        const result = await listStarredSegments.execute();
+
+        expect(result.isError).toBeUndefined();
+        expect(result.content[0].text).toBe("No starred segments found.");
+    });
+
+    it("returns segments with km units for metric athlete", async () => {
+        process.env.STRAVA_ACCESS_TOKEN = "test-token";
+        vi.mocked(getAuthenticatedAthlete).mockResolvedValue({
+            ...mockAthlete,
+            measurement_preference: "meters",
+        });
+        vi.mocked(fetchSegments).mockResolvedValue([mockSegment] as any);
+
+        const result = await listStarredSegments.execute();
+
+        expect(result.isError).toBeUndefined();
+        expect(result.content[0].text).toContain("KOM Hill");
+        expect(result.content[0].text).toContain("km");
+    });
+
+    it("returns segments with mi units for imperial athlete", async () => {
+        process.env.STRAVA_ACCESS_TOKEN = "test-token";
+        vi.mocked(getAuthenticatedAthlete).mockResolvedValue({
+            ...mockAthlete,
+            measurement_preference: "feet",
+        });
+        vi.mocked(fetchSegments).mockResolvedValue([mockSegment] as any);
+
+        const result = await listStarredSegments.execute();
+
+        expect(result.isError).toBeUndefined();
+        expect(result.content[0].text).toContain("KOM Hill");
+        expect(result.content[0].text).toContain("mi");
+    });
+
+    it("returns error on API failure", async () => {
+        process.env.STRAVA_ACCESS_TOKEN = "test-token";
+        vi.mocked(getAuthenticatedAthlete).mockRejectedValue(new Error("Segment fetch failed"));
+
+        const result = await listStarredSegments.execute();
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("Segment fetch failed");
+    });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,14 @@ export default defineConfig({
     test: {
         environment: "node",
         include: ["tests/**/*.test.ts"],
+        coverage: {
+            provider: "v8",
+            include: ["src/**/*.ts"],
+            exclude: ["src/server.ts", "src/tools/connectStrava.ts"],
+            thresholds: {
+                lines: 70,
+                functions: 70,
+            },
+        },
     },
 });


### PR DESCRIPTION
## Summary

- **142 tests passing** (73 new): formatters, formatWorkoutFile, getActivityDetails, getAthleteStats, getRecentActivities, listAthleteClubs, listStarredSegments — covering token errors, success paths, API errors, metric/imperial formatting
- **Fix 3 typos**: `" MNo recent activities found."` → `"No recent activities found."` in getRecentActivities, listAthleteClubs, listStarredSegments
- **Remove debug log**: stale `console.error('[DEBUG stravaClient]...')` in request error interceptor
- **Add eslint.config.js**: flat config so the existing `npm run lint` script actually works (was broken — ESLint was installed but had no config file)
- **Add `@vitest/coverage-v8`** and `test:coverage` script; coverage thresholds at 70%
- **Add SECURITY.md** with token/credential guidance
- **Add GitHub Actions CI** (`.github/workflows/ci.yml`): lint + test-with-coverage jobs, triggers on push/PR to main

## Test plan

- [x] `npm test` — all 142 tests pass
- [x] `npm run test:coverage` — coverage thresholds met
- [x] Typo fixes verified by test assertions (e.g., `listAthleteClubs` test checks for `"No clubs found"`)
- [x] ESLint config verified locally (`npx eslint src --ext .ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)