### PR TITLE
set weight to be optional in DetailedAthleteSchema

### DIFF
--- a/src/stravaClient.ts
+++ b/src/stravaClient.ts
@@ -59,7 +59,7 @@ const DetailedAthleteSchema = BaseAthleteSchema.extend({
     updated_at: z.string().datetime(),
     profile_medium: z.string().url(),
     profile: z.string().url(),
-    weight: z.number().nullable(),
+    weight: z.number().optional().nullable(),
     measurement_preference: z.enum(["feet", "meters"]).optional().nullable(),
     bikes: z.array(z.object({
         id: z.string(),


### PR DESCRIPTION
Got this error from strava:
```
Strava API raw response data (getAuthenticatedAthlete): {
  "id": __HIDDEN__,
  "username": null,
  "resource_state": 2,
  "firstname": "__HIDDEN__",
  "lastname": "__HIDDEN__",
  "bio": "Trailrunner",
  "city": "__HIDDEN__",
  "state": "Montenegro",
  "country": null,
  "sex": "F",
  "premium": false,
  "summit": false,
  "created_at": "2021-10-03T19:39:19Z",
  "updated_at": "2026-01-01T18:07:11Z",
  "badge_type_id": 0,
  "profile_medium": "https://__HIDDEN__",
  "profile": "https://__HIDDEN__",
  "friend": null,
  "follower": null
}
Strava API response validation failed (getAuthenticatedAthlete): ZodError: [
  {
    "code": "invalid_type",
    "expected": "number",
    "received": "undefined",
    "path": [
      "weight"
    ],
    "message": "Required"
  }
]
    at get error [as error] (file:///home/ubuntu/strava-mcp/node_modules/zod/lib/index.mjs:587:31)
    at getAuthenticatedAthlete (file:///home/ubuntu/strava-mcp/dist/stravaClient.js:494:112)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async execute (file:///home/ubuntu/strava-mcp/dist/tools/getAthleteProfile.js:19:29)
    at async file:///home/ubuntu/strava-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js:73:28 {
  issues: [
    {
      code: 'invalid_type',
      expected: 'number',
      received: 'undefined',
      path: [Array],
      message: 'Required'
    }
  ],
  addIssue: [Function (anonymous)],
  addIssues: [Function (anonymous)],
  errors: [
    {
      code: 'invalid_type',
      expected: 'number',
      received: 'undefined',
      path: [Array],
      message: 'Required'
    }
  ]
}
```
The fix is to make `weight` property optional in ZOD schema to pass validation