### PR TITLE
fix: update toolFilter test assertion to match current format (#45)

### DIFF
--- a/tests/getAllActivities.toolFilter.test.ts
+++ b/tests/getAllActivities.toolFilter.test.ts
@@ -35,7 +35,7 @@ describe("get-all-activities tool", () => {
             const text = result.content[0]?.text ?? "";
             expect(text).toContain("**Found 1 activities**");
             expect(text).toContain("ID: 1234567890");
-            expect(text).toContain(" - Run - ");
+            expect(text).toContain("Run Test Run");
         } finally {
             process.env.STRAVA_ACCESS_TOKEN = previousToken;
         }


### PR DESCRIPTION
## Summary

`formatActivitySummary` was updated to use the format `${type} ${name} (ID: ${id}) - ${distance} in ${duration} on ${date}`, so the assertion ` - Run - ` in `tests/getAllActivities.toolFilter.test.ts` no longer matches.

Switching to `Run Test Run` keeps the original intent of the test (verify the activity type is preserved in the formatted output via the `type ${name}` prefix) and matches the new format.

Closes #45

## Test plan

- [x] `npx vitest run tests/getAllActivities.toolFilter.test.ts` — passes