### PR TITLE
fix: make athlete weight field optional in Zod schema

### DIFF
--- a/src/stravaClient.ts
+++ b/src/stravaClient.ts
@@ -59,7 +59,7 @@ const DetailedAthleteSchema = BaseAthleteSchema.extend({
     updated_at: z.string().datetime(),
     profile_medium: z.string().url(),
     profile: z.string().url(),
-    weight: z.number().nullable(),
+    weight: z.number().nullable().optional(),
     measurement_preference: z.enum(["feet", "meters"]).optional().nullable(),
     bikes: z.array(z.object({
         id: z.string(),


### PR DESCRIPTION
## Problem

The `weight` field in the DetailedAthlete Zod schema is marked as `.nullable()` but NOT `.optional()`. When the Strava API returns an athlete profile without a `weight` field (which is common — weight isn't always present), Zod throws a validation error and crashes the server.

```typescript
// Before (line 62 of src/stravaClient.ts)
weight: z.number().nullable(),
// After
weight: z.number().nullable().optional(),
```

## Root Cause

`.nullable()` allows the value `null`, but does NOT allow the field to be completely absent from the object. `.optional()` is required to handle missing keys. Without it, any athlete profile lacking a weight field causes Zod to throw.

## Fix

Add `.optional()` to the weight field chain so it handles both `null` values AND absent fields.